### PR TITLE
Maid 786 fixing undefined behavior

### DIFF
--- a/src/maidsafe/launcher/ui/helpers/application.cc
+++ b/src/maidsafe/launcher/ui/helpers/application.cc
@@ -34,7 +34,7 @@ ExceptionEvent::~ExceptionEvent() = default;
 
 QString ExceptionEvent::ExceptionMessage() { return exception_message_; }
 
-Application::Application(int argc, char** argv)
+Application::Application(int& argc, char** argv)
     : QApplication(argc, argv),
       handler_object_(),
       translators_(),
@@ -62,8 +62,10 @@ bool Application::notify(QObject* receiver, QEvent* event) {
   }
   catch (...) {
     if (handler_object_) {
+      /*
       QApplication::instance()->postEvent(&(*handler_object_),
                                           new ExceptionEvent(tr("Unknown Exception")));
+                                          */
     } else {
       QApplication::quit();
     }

--- a/src/maidsafe/launcher/ui/helpers/application.cc
+++ b/src/maidsafe/launcher/ui/helpers/application.cc
@@ -62,10 +62,8 @@ bool Application::notify(QObject* receiver, QEvent* event) {
   }
   catch (...) {
     if (handler_object_) {
-      /*
       QApplication::instance()->postEvent(&(*handler_object_),
                                           new ExceptionEvent(tr("Unknown Exception")));
-                                          */
     } else {
       QApplication::quit();
     }

--- a/src/maidsafe/launcher/ui/helpers/application.h
+++ b/src/maidsafe/launcher/ui/helpers/application.h
@@ -50,7 +50,7 @@ class ExceptionEvent : public QEvent {
 
 class Application : public QApplication {
  public:
-  Application(int argc, char** argv);
+  Application(int& argc, char** argv);
   QStringList AvailableTranslations();
   void SwitchLanguage(QString language);
   virtual bool notify(QObject* receiver, QEvent* event);


### PR DESCRIPTION
QApplication takes argc by reference. maidsafe::launcher::ui::Application which inherits it passed it a temporary which would be destroyed when the stack for the contructor call unwounded. Fixed by passing reference to the original argc from main(..)
